### PR TITLE
(feature) extract create post buttons; set space in PostDialog

### DIFF
--- a/components/Dialog/PostDialog.tsx
+++ b/components/Dialog/PostDialog.tsx
@@ -1,20 +1,51 @@
-import React, { FunctionComponent } from 'react'
+import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
 import BaseDialog from 'components/Dialog/BaseDialog'
 import PostForm from 'components/Post/PostForm'
+import type { SpaceType } from 'lib/types'
+import useStore from 'lib/store'
 
 interface PostDialogProps {
   showDialog: boolean
   onClose: () => void
 }
 
-const PostDialog: FunctionComponent<PostDialogProps> = ({ showDialog, onClose }) => (
-  <BaseDialog
-    showDialog={showDialog}
-    onClose={onClose}
-    clickOutside
-    body={<PostForm spaceId={1} isTransparent autoFocus />}
-    width='2xl'
-  />
-)
+const PostDialog = ({ showDialog, onClose }: PostDialogProps) => {
+  const [currentSpace, setCurrentSpace] = useState<SpaceType | undefined>()
+  const [isSignedUp, spaces] = useStore((state) => [state.isSignedUp, state.spaces, state.userId])
+  const { query } = useRouter()
+
+  useEffect(() => {
+    if (showDialog) {
+      const urlSpaceName = query.name
+
+      // Either set the state found by url name or use a default space for now
+      if (urlSpaceName) {
+        setCurrentSpace(spaces.find((space: SpaceType) => space.name === urlSpaceName))
+      } else {
+        setCurrentSpace(spaces.find((space: SpaceType) => space.id === 1))
+      }
+    }
+  }, [showDialog, spaces, query.name])
+
+  if (!isSignedUp || !showDialog) {
+    return null
+  }
+
+  return (
+    <BaseDialog
+      showDialog={showDialog}
+      onClose={onClose}
+      clickOutside
+      body={
+        <div>
+          <div className='mb-6'>{currentSpace?.name}</div>
+          {currentSpace && <PostForm spaceId={currentSpace.id} isTransparent autoFocus />}
+        </div>
+      }
+      width='2xl'
+    />
+  )
+}
 
 export default PostDialog

--- a/components/Navigation/AsideButtonCreatePost.tsx
+++ b/components/Navigation/AsideButtonCreatePost.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react'
+import { style } from 'styles/style'
+import PostDialog from 'components/Dialog/PostDialog'
+import useStore from 'lib/store'
+import SVGIcon from 'components/Icon/SVGIcon'
+
+const AsideButtonCreatePost = () => {
+  const [isSignedUp] = useStore((state) => [state.isSignedUp, state.userName])
+
+  const [openPostDialog, setOpenPostDialog] = useState(false)
+
+  // Hidden Post Buttton
+  const postButtonIsHidden = true
+
+  if (!isSignedUp || postButtonIsHidden) {
+    return null
+  }
+
+  return (
+    <>
+      <div className={style.navigationAsideButtonSpacer} />
+      <button
+        type='submit'
+        className={`
+          ${style.button}
+          ${style.buttonDecensored}
+          ${style.buttonNoXsPadding}
+        `}
+        onClick={() => setOpenPostDialog(true)}
+      >
+        <SVGIcon icon='faRocket' isFixed />
+        <span className='hidden whitespace-nowrap sm:inline sm:pl-1'>New Post</span>
+      </button>
+
+      <PostDialog showDialog={openPostDialog} onClose={() => setOpenPostDialog(false)} />
+    </>
+  )
+}
+
+export default AsideButtonCreatePost

--- a/components/Navigation/AsideNavigation.tsx
+++ b/components/Navigation/AsideNavigation.tsx
@@ -10,34 +10,26 @@ import AsideNavigationItem from 'components/Navigation/AsideNavigationItem'
 import SocialIcons from 'components/Navigation/SocialIcons'
 import { getTrendingHashtags } from 'lib/storeUtils'
 import Tag from 'components/Tags/Tag'
-// import PostDialog from 'components/Dialog/PostDialog' // Hidden Post Buttton
+import AsideButtonCreatePost from './AsideButtonCreatePost'
 
 const AsideNavigation: FunctionComponent = () => {
-  // const [openPostDialog, setOpenPostDialog] = useState(false) // Hidden Post Buttton
-  const router = useRouter()
-  const { pathname } = router
-
-  let tabIndex = -1
-  if (pathname === '/') tabIndex = 0
-  else if (pathname.startsWith('/spaces')) tabIndex = 1
-  else if (pathname.startsWith('/space/')) tabIndex = 2
-  else if (pathname.startsWith('/bookmarks/')) tabIndex = 3
-  else if (pathname.startsWith('/likes/')) tabIndex = 4
-  else if (pathname.startsWith('/user/')) tabIndex = 5
-
   const [isSignedUp, userName, posts] = useStore((state) => [state.isSignedUp, state.userName, state.posts])
   const [isDarkmode, setIsDarkmode] = useStore((state) => [state.isDarkmode, state.setIsDarkmode])
 
-  const toggleDarkMode = (): void => {
-    if (isDarkmode) {
-      setIsDarkmode(false)
-    } else {
-      setIsDarkmode(true)
-    }
-  }
+  const router = useRouter()
+  const { pathname } = router
+
+  const isRoot = pathname === '/'
+  const isSpaces = pathname.startsWith('/spaces')
+  const isBookmarks = pathname.startsWith('/bookmarks/')
+  const isLikes = pathname.startsWith('/likes/')
+  const isUser = pathname.startsWith('/user/')
+
+  const toggleDarkMode = (): void => setIsDarkmode(!isDarkmode)
 
   // Get trending hashtags
   const hashtags = getTrendingHashtags(posts, 12, 1)
+
   const trendingTags = hashtags.map((tag: any) => (
     <Link href={`/tag/${tag.tag}`} passHref>
       <a href='passed'>
@@ -55,62 +47,38 @@ const AsideNavigation: FunctionComponent = () => {
           <div className={style.navigationAsideButtonContainer}>
             <Link href='/' passHref>
               <span>
-                <AsideNavigationItem isActive={tabIndex === 0} icon='faSatelliteDish' name='Feed' />
+                <AsideNavigationItem isActive={isRoot} icon='faSatelliteDish' name='Feed' />
               </span>
             </Link>
             <Link href='/spaces' passHref>
               <span>
-                <AsideNavigationItem isActive={tabIndex === 1} icon='faSatellite' name='Spaces' />
+                <AsideNavigationItem isActive={isSpaces} icon='faSatellite' name='Spaces' />
               </span>
             </Link>
             {isSignedUp && (
               <>
                 <Link href={`/user/${userName}`} passHref>
                   <span>
-                    <AsideNavigationItem isActive={tabIndex === 5} icon='faUserAstronaut' name='My Posts' />
+                    <AsideNavigationItem isActive={isUser} icon='faUserAstronaut' name='My Posts' />
                   </span>
                 </Link>
-
                 <Tooltip classNames='disabled-link' text='Good things take time'>
                   <Link href='/' passHref>
                     <span>
-                      <AsideNavigationItem isActive={tabIndex === 3} icon='faBookmark' name='Bookmarks' />
+                      <AsideNavigationItem isActive={isBookmarks} icon='faBookmark' name='Bookmarks' />
                     </span>
                   </Link>
                 </Tooltip>
-
                 <Tooltip classNames='disabled-link' text='Good things take time'>
                   <Link href='/' passHref>
                     <span>
-                      <AsideNavigationItem isActive={tabIndex === 4} icon='faHeart' name='Likes' />
+                      <AsideNavigationItem isActive={isLikes} icon='faHeart' name='Likes' />
                     </span>
                   </Link>
                 </Tooltip>
-
                 <span className='pt-5'>Trending</span>
                 {trendingTags}
-
-                {/* Hidden Post Buttton */}
-                {/* <div className={style.navigationAsideButtonSpacer} />
-                <button
-                  type='submit'
-                  className={`
-                   ${style.button}
-                   ${style.buttonDecensored}
-                   ${style.buttonNoXsPadding}
-                  `}
-                  onClick={() => setOpenPostDialog(true)}
-                >
-                  <SVGIcon icon='faRocket' isFixed/>
-                  <span className='whitespace-nowrap hidden sm:inline sm:pl-1'>
-                    New Post
-                  </span>
-                </button>
-
-                <PostDialog
-                  showDialog={openPostDialog}
-                  onClose={() => setOpenPostDialog(false)}
-                /> */}
+                <AsideButtonCreatePost />
               </>
             )}
           </div>

--- a/components/Navigation/BottomButtonCreatePost.tsx
+++ b/components/Navigation/BottomButtonCreatePost.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import { style } from 'styles/style'
+import PostDialog from 'components/Dialog/PostDialog'
+import useStore from 'lib/store'
+import SVGIcon from 'components/Icon/SVGIcon'
+
+const BottomButtonCreatePost = () => {
+  const [isSignedUp] = useStore((state) => [state.isSignedUp])
+
+  const [openPostDialog, setOpenPostDialog] = useState(false)
+
+  // Hidden Post Buttton
+  const postButtonIsHidden = true
+
+  if (!isSignedUp || postButtonIsHidden) {
+    return null
+  }
+
+  return (
+    <>
+      <div className={style.navigationBottomPostButtonWrapper}>
+        <div
+          className={`
+                ${style.navigationBottomPostButtonPseudo}
+                ${style.navigationBottomPostButtonBefore}
+                ${style.navigationBottomPostButtonBeforeDark}
+              `}
+        >
+          <div
+            className={`
+                  ${style.navigationBottomPostButtonPseudoInner}
+                  ${style.navigationBottomPostButtonBeforeInner}
+                  ${style.navigationBottomPostButtonBeforeInnerDark}
+                `}
+          />
+        </div>
+        <button
+          type='button'
+          className={`${style.navigationBottomPostButton} ${style.buttonDecensored}`}
+          onClick={() => setOpenPostDialog(true)}
+        >
+          <SVGIcon icon='faRocket' />
+        </button>
+        <div
+          className={`
+                ${style.navigationBottomPostButtonPseudo}
+                ${style.navigationBottomPostButtonAfter}
+                ${style.navigationBottomPostButtonAfterDark}
+              `}
+        >
+          <div
+            className={`
+                  ${style.navigationBottomPostButtonPseudoInner}
+                  ${style.navigationBottomPostButtonAfterInner}
+                  ${style.navigationBottomPostButtonAfterInnerDark}
+                `}
+          />
+        </div>
+      </div>
+      <PostDialog showDialog={openPostDialog} onClose={() => setOpenPostDialog(false)} />
+    </>
+  )
+}
+
+export default BottomButtonCreatePost

--- a/components/Navigation/BottomNavigation.tsx
+++ b/components/Navigation/BottomNavigation.tsx
@@ -1,25 +1,16 @@
-import React, { FunctionComponent, useState } from 'react'
+import React from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import SVGIcon from 'components/Icon/SVGIcon'
-import useStore from 'lib/store'
 import { style } from 'styles/style'
-import PostDialog from 'components/Dialog/PostDialog'
+import BottomButtonCreatePost from './BottomButtonCreatePost'
 
-const BottomNavigation: FunctionComponent = () => {
-  const [openPostDialog, setOpenPostDialog] = useState(false)
-  const router = useRouter()
-  const { pathname } = router
+const BottomNavigation = () => {
+  const { pathname } = useRouter()
 
-  // Hidden Post Buttton
-  const postButtonIsHidden = true
-
-  let tabIndex = -1
-  if (pathname === '/') tabIndex = 0
-  else if (pathname.startsWith('/spaces')) tabIndex = 1
-
-  const [isSignedUp] = useStore((state) => [state.isSignedUp, state.userName])
+  const isRoot = pathname === '/'
+  const isSpaces = pathname.startsWith('/spaces')
 
   return (
     <div
@@ -34,12 +25,12 @@ const BottomNavigation: FunctionComponent = () => {
           <span
             className={`
               ${style.navigationBottomItem}
-              ${tabIndex === 0 ? style.navigationBottomItemColorActive : style.navigationBottomItemColor}
+              ${isRoot ? style.navigationBottomItemColorActive : style.navigationBottomItemColor}
             `}
           >
             <SVGIcon icon='faSatelliteDish' />
             <span className={style.navigationBottomItemText}>Feed</span>
-            {tabIndex === 0 && (
+            {isRoot && (
               <motion.span
                 className={`
                   ${style.navigationBottomMotionSpan}
@@ -52,61 +43,18 @@ const BottomNavigation: FunctionComponent = () => {
           </span>
         </Link>
 
-        {isSignedUp && !postButtonIsHidden && (
-          <>
-            <div className={style.navigationBottomPostButtonWrapper}>
-              <div
-                className={`
-                ${style.navigationBottomPostButtonPseudo}
-                ${style.navigationBottomPostButtonBefore}
-                ${style.navigationBottomPostButtonBeforeDark}
-              `}
-              >
-                <div
-                  className={`
-                  ${style.navigationBottomPostButtonPseudoInner}
-                  ${style.navigationBottomPostButtonBeforeInner}
-                  ${style.navigationBottomPostButtonBeforeInnerDark}
-                `}
-                />
-              </div>
-              <button
-                type='button'
-                className={`${style.navigationBottomPostButton} ${style.buttonDecensored}`}
-                onClick={() => setOpenPostDialog(true)}
-              >
-                <SVGIcon icon='faRocket' />
-              </button>
-              <div
-                className={`
-                ${style.navigationBottomPostButtonPseudo}
-                ${style.navigationBottomPostButtonAfter}
-                ${style.navigationBottomPostButtonAfterDark}
-              `}
-              >
-                <div
-                  className={`
-                  ${style.navigationBottomPostButtonPseudoInner}
-                  ${style.navigationBottomPostButtonAfterInner}
-                  ${style.navigationBottomPostButtonAfterInnerDark}
-                `}
-                />
-              </div>
-            </div>
-            <PostDialog showDialog={openPostDialog} onClose={() => setOpenPostDialog(false)} />
-          </>
-        )}
+        <BottomButtonCreatePost />
 
         <Link href='/spaces' passHref>
           <span
             className={`
               ${style.navigationBottomItem}
-              ${tabIndex === 1 ? style.navigationBottomItemColorActive : style.navigationBottomItemColor}
+              ${isSpaces ? style.navigationBottomItemColorActive : style.navigationBottomItemColor}
             `}
           >
             <SVGIcon icon='faSatellite' />
             <span className={style.navigationBottomItemText}>Spaces</span>
-            {tabIndex === 1 && (
+            {isSpaces && (
               <motion.span
                 className={`
                   ${style.navigationBottomMotionSpan}


### PR DESCRIPTION
Hi guys,

this is a first commit for creating posts with the "Create Post" buttons from side and bottom navigation.

As there are multiple placed to trigger the dialog from, I decided to move the logic for figuring the current space into the dialog itself.

Next step would be to handle the case when there is no space selected and allow the user to select the space rather than pre-defining one.

Reason I'm creating this PR is to avoid merge conflicts down the road and to make transparent on what I'm working.

Please let me know when something needs to be changed or when there are questions, otherwise I continue with the PostDialog.